### PR TITLE
Nova representação de upvotes de um Look

### DIFF
--- a/components/buttons/icons/LookUpvoteButton.jsx
+++ b/components/buttons/icons/LookUpvoteButton.jsx
@@ -1,6 +1,7 @@
 //Icone de upvote, com e sem preenchimento
 import ForwardIcon from "@mui/icons-material/Forward";
 import ForwardOutlinedIcon from "@mui/icons-material/ForwardOutlined";
+import formatCompactNumbers from "@/utils/formatCompactNumbers";
 
 export default function LookUpvoteButton({ upvotes }) {
   return (
@@ -9,7 +10,7 @@ export default function LookUpvoteButton({ upvotes }) {
     >
       <ForwardOutlinedIcon className="text-white -rotate-90" />
       <div className="text-center">
-        <h6 className="font-semibold text-white">{upvotes}</h6>
+        <h6 className="font-semibold text-white">{formatCompactNumbers(upvotes)}</h6>
       </div>
     </div>
   );

--- a/utils/formatCompactNumbers.js
+++ b/utils/formatCompactNumbers.js
@@ -1,0 +1,5 @@
+export default function formatCompactNumbers (number)
+{
+    const formatador = Intl.NumberFormat("en", { notation: "compact" });
+    return formatador.format(number);
+}


### PR DESCRIPTION
Os números apresentados num upvote passam agora a arredondar segundo um formatação compacta inglesa, utilizando a util function criada
(formatCompactNumbers). Isto significa que um look com 1200 upvotes, passa a mostrar 1.2K.
Para tal, foi utilizado o objeto Intl.NumberFormat.

Esta forma de arredondamento pode ser utilizada noutros lugares, por exemplo, na representação dos pontos, bastando apenas invocar a função criada