### PR TITLE
Arredondar cantos da card da galeria

### DIFF
--- a/components/buttons/icons/LookUpvoteButton.jsx
+++ b/components/buttons/icons/LookUpvoteButton.jsx
@@ -6,7 +6,7 @@ import formatCompactNumbers from "@/utils/formatCompactNumbers";
 export default function LookUpvoteButton({ upvotes }) {
   return (
     <div
-      className="absolute top-0 right-0 w-[70px] h-[45px] bg-black rounded-tr-[5px]} rounded-bl-[5px] justify-center items-center inline-flex"
+      className="absolute top-0 right-0 w-[70px] h-[45px] bg-black rounded-tr-[5px] rounded-bl-[5px] justify-center items-center inline-flex"
     >
       <ForwardOutlinedIcon className="text-white -rotate-90" />
       <div className="text-center">


### PR DESCRIPTION
O canto superior-direito do botão de upvote da card da galeria foi arredondado. Previamente não estava devido a um pequeno erro na classe de tailwind