### PR TITLE
Elemento de desconto a reencaminhar para produto

### DIFF
--- a/components/cards/CardProduct.jsx
+++ b/components/cards/CardProduct.jsx
@@ -27,7 +27,7 @@ const CardProduct = ({ product, slider, gender, alignPrice }) => {
 
                 <div className='absolute top-2.5 px-4 w-full flex items-center justify-between'>
                     <div className='flex gap-3 items-center'>
-                        <Link href={`/brands/mulher/${product.brands.name}`}>
+                        <Link href={`/brands/${gender.toLowerCase()}/${product.brands.name}`}>
                             <Image
                                 src={product.brands.logo_url}
                                 width={25}
@@ -45,10 +45,12 @@ const CardProduct = ({ product, slider, gender, alignPrice }) => {
 
 
                 {product.discount > 0 &&
+                    <Link href={`/product/${gender.toLowerCase()}/${product.id}`}>
                     <div className='h-11 bg-primary_main absolute bottom-5 text-white flex items-center gap-2 font-medium px-3.5 rounded-tr rounded-br left-0'>
                         <SellIcon sx={{ fontSize: 20 }} />
                         {product.discount}% OFF
                     </div>
+                    </Link>
                 }
 
             </div>


### PR DESCRIPTION
O elemento que mostra o desconto existente de uma peça passa agora a reencaminhar para a própria peça quando clicado.

Também o símbolo da marca, no topo esquerdo da card de produto reencaminha para a página da marca mediante o género escolhido. Previamente, reencaminhava sempre para a página de mulher